### PR TITLE
Fix error no such file or directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 package-lock.json
 package.json
-bin

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,12 +2,15 @@
 
 import fs from "fs";
 import path from "path";
+import url from "url";
 
 const options = {
   encoding: "utf8",
   flag: "r",
 };
 
-const card = fs.readFileSync(path.join(path.resolve(), "bin/card"), options);
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const card = fs.readFileSync(path.join(__dirname, "card"), options);
 
 console.log(card);

--- a/build.js
+++ b/build.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import url from "url";
 import chalk from "chalk";
 import boxen from "boxen";
 
@@ -42,7 +43,9 @@ const boxenOptions = {
 
 const data = chalk.green(boxen(text.trim(), boxenOptions));
 
-const file = path.join(path.resolve(), "bin/card");
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const file = path.join(__dirname, "bin", "card");
 
 const writeFileOptions = {
   encoding: "utf8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techeverri",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Personal card for Tomas Echeverri (@techeverri)",
   "keywords": [
     "business card",


### PR DESCRIPTION
### Summary

- Format files in `bin` folder
- Use `__dirname` instead of `path.resolve()`. fixes #1 
_In other words, use the module's path instead of the working directory._
- Bump version number 1.1.0