### PR TITLE
fix: address code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ${{ matrix.virtual-environment }}
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
 
   print:
     needs: build
+    permissions:
+      contents: read
     runs-on: ${{ matrix.virtual-environment }}
 
     strategy:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   ci:
     uses: techeverri/techeverri-cli/.github/workflows/ci.yml@main
+    permissions:
+      contents: read
 
   publish-npm:
     needs: ci


### PR DESCRIPTION
This PR addresses the following code scanning alerts by adding explicit permissions to the GitHub Actions workflows:

- Fixes https://github.com/techeverri/techeverri-cli/security/code-scanning/1
- Fixes https://github.com/techeverri/techeverri-cli/security/code-scanning/2
- Fixes https://github.com/techeverri/techeverri-cli/security/code-scanning/3