### PR TITLE
Optimize CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,12 @@ jobs:
     needs: build
     permissions:
       contents: read
-    runs-on: ${{ matrix.virtual-environment }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        # See supported GitHub-hosted runners https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
-        virtual-environment: [macos-latest, ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [16, 18, 20, 22]
+        node-version: [16, 22]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Reduces CI test jobs from 12 to 2 by:
- Testing only on Ubuntu (instead of macOS, Ubuntu, Windows)
- Testing only Node 16 and 22 (min and max supported versions)

The CLI performs basic file I/O that's platform-agnostic, so cross-platform testing is unnecessary. Testing min and max Node versions provides adequate coverage.